### PR TITLE
chore: update configSlice name to avoid conflict

### DIFF
--- a/apps/builder/src/redux/config/configSlice.ts
+++ b/apps/builder/src/redux/config/configSlice.ts
@@ -22,7 +22,7 @@ import {
 import { ConfigInitialState } from "@/redux/config/configState"
 
 const configSlice = createSlice({
-  name: "builderInfo",
+  name: "config",
   initialState: ConfigInitialState,
   reducers: {
     resetConfig,


### PR DESCRIPTION
## 📝 Description

The slice name currently conflicts with [`builderInfo`](https://github.com/kodjunkie/illa-builder/blob/bff8f05432527cfba438a9715f1002492721a392/apps/builder/src/redux/builderInfo/builderInfoSlice.ts#L6)

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

N/A