### PR TITLE
fix: add formDataKey for radioButton panelConfig

### DIFF
--- a/apps/builder/src/widgetLibrary/RadioButtonWidget/panelConfig.tsx
+++ b/apps/builder/src/widgetLibrary/RadioButtonWidget/panelConfig.tsx
@@ -214,6 +214,20 @@ export const RADIO_BUTTON_PANEL_CONFIG: PanelConfig[] = [
     ],
   },
   {
+    id: `${baseWidgetName}-validation`,
+    groupName: i18n.t("editor.inspect.setter_group.validation"),
+    children: [
+      {
+        id: `${baseWidgetName}-validation-form-data-key`,
+        labelName: i18n.t("editor.inspect.setter_label.form_data_key"),
+        labelDesc: i18n.t("editor.inspect.setter_tooltip.form_data_key"),
+        setterType: "INPUT_SETTER",
+        expectedType: VALIDATION_TYPES.STRING,
+        attrName: "formDataKey",
+      },
+    ],
+  },
+  {
     id: `${baseWidgetName}-layout`,
     groupName: i18n.t("editor.inspect.setter_group.layout"),
     children: [


### PR DESCRIPTION
## 📝 Description

Error is reported after changing the radioButton component name, but there is no place to change it. Add formDataKey for radioButton panelConfig.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

![截屏](https://user-images.githubusercontent.com/348866/210307077-db17f856-bb1d-41d2-9fc0-1adf9ed152a7.png)
