### PR TITLE
chore(intl): point i18n type definition to the right resource

### DIFF
--- a/apps/builder/src/i18n/react-i18next.d.ts
+++ b/apps/builder/src/i18n/react-i18next.d.ts
@@ -2,6 +2,6 @@ import { resources } from "./config"
 
 declare module "react-i18next" {
   interface CustomTypeOptions {
-    resources: typeof resources["en"]
+    resources: typeof resources["en-US"]
   }
 }

--- a/apps/builder/src/utils/dayjs.ts
+++ b/apps/builder/src/utils/dayjs.ts
@@ -19,11 +19,11 @@ const PER_HOUR = PER_MINUTE * 60
 const PER_DAY = PER_HOUR * 24
 
 const FORMAT_RULE = {
-  "zh-CN": {
+  "zh-cn": {
     inYear: "MMMD日 HH:MM",
     otherYear: "YYYY年MMMDD日HH:MM",
   },
-  "en-US": {
+  "en-us": {
     inYear: "HH:MM MMM DD",
     otherYear: "HH:MM MMM DD, YYYY",
   },
@@ -51,20 +51,20 @@ export const fromNow = (date: string) => {
   if (!date) return ""
   const now = dayjs()
   const diff = now.diff(date)
-  const local = dayjs.locale() as "zh-CN" | "en-US"
+  const local = dayjs.locale() as "zh-cn" | "en-us"
   if (diff / PER_MINUTE <= 1) {
     return i18n.t("dayjs.just_now")
   }
 
   if (diff / PER_DAY >= 7 && dayjs(date).isSame(now, "year")) {
     return dayjs(date).format(
-      FORMAT_RULE[local]?.inYear || FORMAT_RULE["en-US"].inYear,
+      FORMAT_RULE[local]?.inYear || FORMAT_RULE["en-us"].inYear,
     )
   }
 
   if (diff / PER_DAY >= 7 && !dayjs(date).isSame(now, "year")) {
     return dayjs(date).format(
-      FORMAT_RULE[local].otherYear || FORMAT_RULE["en-US"].otherYear,
+      FORMAT_RULE[local]?.otherYear || FORMAT_RULE["en-us"].otherYear,
     )
   }
   return dayjs(date).fromNow()


### PR DESCRIPTION
## 📝 Description

Key `en` doesn't exist in the [`resource`](https://github.com/illacloud/illa-builder/blob/main/apps/builder/src/i18n/config.ts#L10-L23) object, `en-US` does.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

lol