### PR TITLE
Fix/edit event handler modal position

### DIFF
--- a/apps/builder/src/page/App/components/PanelSetters/EventHandlerSetter/List/eventAndMethodLabel.tsx
+++ b/apps/builder/src/page/App/components/PanelSetters/EventHandlerSetter/List/eventAndMethodLabel.tsx
@@ -76,7 +76,7 @@ export const EventAndMethodLabel: FC<EventAndMethodLabelProps> = (props) => {
       }
       trigger="click"
       showArrow={false}
-      position="left-start"
+      position="top-start"
       clickOutsideToClose
       onVisibleChange={(visible) => {
         if (visible) {


### PR DESCRIPTION
## 📝 Description

fixes #2090
Solves the problem by making modal position from left-start to top-start. With this small change, it will be more user friendly and this modal expands above the event handler so that the popup content is fully visible.
<img width="957" alt="git" src="https://github.com/illacloud/illa-builder/assets/44232278/6c8b8592-6d67-4b08-bcf1-f1a71d0dba0f">


## 💣 Is this a breaking change (Yes/No):

- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information