### PR TITLE
fix(typo): change showTollBar to showToolBar

### DIFF
--- a/apps/builder/src/widgetLibrary/PdfWidget/interface.tsx
+++ b/apps/builder/src/widgetLibrary/PdfWidget/interface.tsx
@@ -11,7 +11,7 @@ export interface WrappedPdfProps
   height?: number
   scaleMode?: "width" | "height"
   url?: string
-  showTollBar?: boolean
+  showToolBar?: boolean
 }
 
 export interface PdfWidgetProps

--- a/apps/builder/src/widgetLibrary/PdfWidget/panelConfig.tsx
+++ b/apps/builder/src/widgetLibrary/PdfWidget/panelConfig.tsx
@@ -26,7 +26,7 @@ export const PDF_PANEL_CONFIG: PanelConfig[] = [
         id: `${baseWidgetName}-layout-show-tool-bar`,
         labelName: i18n.t("editor.inspect.setter_label.show_tool_bar"),
         setterType: "DYNAMIC_SWITCH_SETTER",
-        attrName: "showTollBar",
+        attrName: "showToolBar",
         placeholder: "{{false}}",
         useCustomLayout: true,
         openDynamic: true,

--- a/apps/builder/src/widgetLibrary/PdfWidget/pdf.tsx
+++ b/apps/builder/src/widgetLibrary/PdfWidget/pdf.tsx
@@ -38,7 +38,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = pdfWorker
 // pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`
 
 export const Pdf = forwardRef<HTMLDivElement, WrappedPdfProps>((props, ref) => {
-  const { displayName, width, height, scaleMode, url, showTollBar } = props
+  const { displayName, width, height, scaleMode, url, showToolBar } = props
   const { t } = useTranslation()
   const pageRef = useRef<HTMLDivElement[]>([])
   const documentRef = useRef<HTMLDivElement>(null)
@@ -124,7 +124,7 @@ export const Pdf = forwardRef<HTMLDivElement, WrappedPdfProps>((props, ref) => {
           <Loading />
         </div>
       ) : null}
-      {showTollBar && !error && !loading ? (
+      {showToolBar && !error && !loading ? (
         <div css={[toolBarStyle, applyHiddenStyle(loading)]}>
           <ToolButton
             disabled={pageNumber <= 1}
@@ -213,7 +213,7 @@ export const PdfWidget: FC<PdfWidgetProps> = (props) => {
     height,
     scaleMode,
     url,
-    showTollBar,
+    showToolBar,
     w,
     h,
   } = props
@@ -271,7 +271,7 @@ export const PdfWidget: FC<PdfWidgetProps> = (props) => {
           height={height}
           scaleMode={scaleMode}
           url={url}
-          showTollBar={showTollBar}
+          showToolBar={showToolBar}
         />
       </TooltipWrapper>
     </div>

--- a/apps/builder/src/widgetLibrary/PdfWidget/widgetConfig.tsx
+++ b/apps/builder/src/widgetLibrary/PdfWidget/widgetConfig.tsx
@@ -14,7 +14,7 @@ export const PDF_WIDGET_CONFIG: WidgetConfig = {
   defaults: {
     url: "https://upload.wikimedia.org/wikipedia/commons/e/ee/Guideline_No._GD-Ed-2214_Marman_Clamp_Systems_Design_Guidelines.pdf",
     hidden: false,
-    showTollBar: true,
+    showToolBar: true,
     scaleMode: "width",
     width: undefined,
     height: undefined,


### PR DESCRIPTION
## 📝 Description

This PR fix the issue mention in #1738.
Fix the typo of `showTollBar` to `showToolBar`.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

lol