### PR TITLE
docs: corrected wrong org name in docker command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ ILLA_USE_HTTPS=false
 
 #### If you not have rust
 
-You can use Docker pull image:`docker pull illa-soft/illa-builder:latest`,and then you can run `docker run -d -p 9345:2022 illasoft/illa-builder:latest`,this means you will deploy illa-builder-backend at port 9345. And then you can modify your `.env.development.local`
+You can use Docker pull image:`docker pull illasoft/illa-builder:latest`,and then you can run `docker run -d -p 9345:2022 illasoft/illa-builder:latest`,this means you will deploy illa-builder-backend at port 9345. And then you can modify your `.env.development.local`
 
 
 


### PR DESCRIPTION
## 📝 Description
There is a small typo in a docker command in the contribution docs which leads to a error of image not found

https://github.com/illacloud/illa-builder/issues/2173#issue-1911582528

<img width="1003" alt="illasoft" src="https://github.com/illacloud/illa-builder/assets/68103212/87d9299b-85e4-43e1-9571-6c4261582b90">

**It should be illasoft as per dockerhub**
<img width="428" alt="image" src="https://github.com/illacloud/illa-builder/assets/68103212/07129868-8651-4a41-bfcb-7ab4b00fbf4a">



## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

lol