### PR TITLE
fix(bug): Ensure form default values are preserved when resetting

### DIFF
--- a/apps/builder/src/widgetLibrary/FormWidget/form.tsx
+++ b/apps/builder/src/widgetLibrary/FormWidget/form.tsx
@@ -276,7 +276,7 @@ export const FormWidget: FC<FormWidgetProps> = (props) => {
       return {
         displayName: node.displayName,
         value: {
-          value: "",
+          value: node.props!.value,
           validateMessage: "",
         },
       }


### PR DESCRIPTION
## 📝 Description

This PR resolves issue #2087, where resetting a form caused the default values of form inputs to be reset. In the current version, this issue manifested as follows:

#### Before Reset:

![ip](https://github.com/illacloud/illa-builder/assets/90558243/024083d5-933c-46ee-bd28-47e63e68b843)
In the above example:

- First Name's default value is set to "John".
- Last Name's default value is set to "Doe".

#### Issue Result:

https://github.com/illacloud/illa-builder/assets/90558243/ef29b5ad-1047-47bf-9361-94e24ce1bdc4

After resetting the form, the default values disappeared.

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information
The reason for this issue is related to the code snippet provided below:
```typescript
return {
        displayName: node.displayName,
        value: {
         // Problem here is that on resetting value is set to ""
          value: "",
          validateMessage: "",
        },
      }
```

By changing the line` value: node.props!.value,` we retrieve the default value of the input field and set it to the input element.

I have made this change locally, built and tested the project, and the result is as follows:

#### Result:
https://github.com/illacloud/illa-builder/assets/90558243/54b42d32-a8f1-45c8-ae3b-964134d69626
 
lol