### PR TITLE
fix(bug): readonly not working date-component

### DIFF
--- a/apps/builder/src/widgetLibrary/DateWidget/date.tsx
+++ b/apps/builder/src/widgetLibrary/DateWidget/date.tsx
@@ -30,6 +30,9 @@ export const WrappedDate: FC<WrappedDateProps> = (props) => {
   } = props
 
   const changeValue = (value?: unknown) => {
+    if (readOnly) {
+      return
+    }
     new Promise((resolve) => {
       const message = getValidateMessage(value)
       handleUpdateMultiExecutionResult([


### PR DESCRIPTION
## 📝 Description

This PR resolves #2481, where value change of date conponent  take place even if it is set readonly as shown below:

#### Issue:

https://github.com/illacloud/illa-builder/assets/90558243/3fdf51fd-8c1d-4c9a-b739-df86fa79f3e6



## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information
In DateWidget the `onchange` method is call even after the readonly is true so adding a check for readonly might semese the solution.

#### Result:

https://github.com/illacloud/illa-builder/assets/90558243/36fe7589-ae07-46ec-9058-16ad0e244abd


 
lol