### PR TITLE
chore: update LICENSE section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,14 @@ Contact Us: hr@illasoft.com
 
 ## LICENSE
 
-This project is currently licensed under [Apache License 2.0](./LICENSE).
+<table>
+  <tr>
+     <td>
+       <p align="center"> <img src="https://github.com/malivinayak/illa-builder/assets/66154908/e290d370-aed3-4c32-bf12-39ef94d2ad22" width="80%"></img>
+    </td>
+    <td> 
+      <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"/> <br> 
+This project is licensed under <a href="./LICENSE">Apache License 2.0</a>. <img width=2300/>
+    </td>
+  </tr>
+</table>

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Contact Us: hr@illasoft.com
 <table>
   <tr>
      <td>
-       <p align="center"> <img src="https://github.com/malivinayak/illa-builder/assets/66154908/e290d370-aed3-4c32-bf12-39ef94d2ad22" width="80%"></img>
+       <p align="center"> <img src="https://github.com/malivinayak/malivinayak/blob/main/LICENSE-Logo/License-Apache.png" width="80%"></img>
     </td>
     <td> 
       <img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"/> <br> 


### PR DESCRIPTION
## 📝 Description

Updated the LICENSE section in the README file to enhance the presentation. Added a Apache logo, license badge and replaced the previous text with a cleaner format, including a hyperlink to the LICENSE file.
![image](https://github.com/illacloud/illa-builder/assets/66154908/d0d9a9da-d57b-4d3e-90a8-a0e982c37d62)


## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.

## 📝 Additional Information

- Current:
> ![image](https://github.com/illacloud/illa-builder/assets/66154908/1c04f025-50a6-4ce8-9b86-7b8d4c444258)
- Updates:
> ![image](https://github.com/illacloud/illa-builder/assets/66154908/d0d9a9da-d57b-4d3e-90a8-a0e982c37d62)
