### PR TITLE
fix: undo/redo not updating execution tree view

### DIFF
--- a/apps/builder/src/redux/currentApp/executionTree/executionListener.ts
+++ b/apps/builder/src/redux/currentApp/executionTree/executionListener.ts
@@ -434,6 +434,7 @@ export function setupExecutionListeners(
       matcher: isAnyOf(
         componentsActions.addComponentReducer,
         componentsActions.updateComponentPropsReducer,
+        componentsActions.setComponentPropsReducer,
         componentsActions.deleteComponentNodeReducer,
         componentsActions.batchUpdateMultiComponentSlicePropsReducer,
         componentsActions.updateMultiComponentPropsReducer,


### PR DESCRIPTION
## 📝 Description

Fix for issue #2095 . It seems that when undo/redo is executed, it dispatches an action called `setComponentPropsReducer`, which was not refreshing the execution tree view. I added it to the list of subscriptions in the `executionListener`. 

Another potential fix would be to get rid of the `setComponentPropsReducer` action all together, and instead modify the undo/redo to dispatch `updateComponentPropsReducer` action. It seems that the `setComponentPropsReducer` is used only by the undo/redo mechanism, so maybe it is not needed at all?

## 💣 Is this a breaking change (Yes/No):

- [ ] Yes
- [x] No

## 🚧 How to migrate?

Don't need.
