### PR TITLE
Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ After successfully deployed, you can register with email address or log in with 
 <p align="left">Username (email): root</p>
 <p align="left">Password: password</p>
 
+You can self-host ILLA in one-click on [Dome](https://app.trydome.io/signup?package=illasoft):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=illasoft)
+    
     
     
 ## How to build your tool

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![PR:s Welcome](https://img.shields.io/badge/PR:s-welcome-brightgreen.svg)](https://github.com/illacloud/illa-builder/pulls)
 [![First Contributors](https://img.shields.io/badge/first-contributors-brightgreen.svg)](https://github.com/illacloud/illa-builder/pulls)
 ![GitHub repo size](https://img.shields.io/github/repo-size/illacloud/illa-builder)
+[![Deploy to Dome](https://trydome.io/dome-badge.svg)](https://app.trydome.io/signup?package=illasoft)
 
 By contributing AI Agents or ILLA Apps to the ILLA community and submitting a pull request to ILLA, you have the opportunity to receive a Digital Reward Kit from Hacktoberfest and Swags from ILLA Cloud.
 


### PR DESCRIPTION
Hey!

We build this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:
https://4730e036c1cac1cb79f81265444aea3dae83e035.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.